### PR TITLE
ACTIN-2464 Container and README for ACTIN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.13.5
+
+ADD actin_curator /trial-curator/actin_curator
+ADD trialcurator /trial-curator/trialcurator
+ADD utils /trial-curator/utils
+RUN pip install --no-cache-dir -r /trial-curator/actin_curator/requirements.txt
+
+ENV PYTHONPATH=/trial-curator
+ENV GOOGLE_GENAI_USE_VERTEXAI=true
+ENV GOOGLE_CLOUD_PROJECT="actin-shared"
+ENV GOOGLE_CLOUD_LOCATION="europe-west4"
+
+ENTRYPOINT [ "python", "-m", "actin_curator.actin_curator", \
+  "--llm_provider", "Google", \
+  "--actin_filepath", "/trial-curator/actin_curator/data/ACTIN_rules/ACTIN_rules_w_categories_13062025.csv", \
+  "--output_file_complete", "/actin_data/output/trial_curator_complete.out", \
+  "--input_text_file", "/actin_data/input/criteria.txt" ]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # trial-curator
+
+AI magic for curating trial protocols automatically!
+
+## Using Under Docker
+
+The ACTIN project has added a `Dockerfile` and wrapper script for easily running the ACTIN curation module against Vertex either
+in GCP somewhere or on a user's machine:
+
+* To obtain a Docker image either:
+  * Issue `docker build .` in the root directory of the project and run `docker images`, noting the "hash" of the `docker` image
+    just built.
+  * OR run `docker pull europe-west4-docker.pkg.dev/actin-build/build-registry-docker/actin-trial-curator:x` where `x` is the tag
+    of the version for an existing container you want.
+* Run `actin_curator.sh` once with the image hash or tag and any directory you would like to use for input/output to/from the
+  container.  Let's use `/tmp/actin_data` for the rest of the steps. The needed directories under `/tmp/actin_data` will be
+  created.
+* Copy your inclusion criteria that should be interpreted into `/tmp/actin_data/input/criteria.txt`.
+* Recall your `actin_curator.sh` command line and run it again, this time it should run for a couple of minutes and then write
+  output from the LLM in `/tmp/actin_data/output`.
+
+### Troubleshooting
+
+* Auth-related issues could be related to not having application-default credentials. Try issuing `gcloud auth application-default
+  login` then re-running the wrapper script.
+* The above notwithstanding, auto-detection of your `gcloud` configuration directory could fail, if you think this is happening
+  try exporting `CLOUDSDK_CONFIG` in the environment that you're running the wrapper script from.
+* Despite having sensible defaults something could need to be adjusted in the Google project or location settings used by the
+  Docker container. You could modify the wrapper with `-e` commands after consulting the `Dockerfile`.
+* You could also simply be lacking permissions.
+
+This setup has not been thoroughly tested so ask for help if it is not working for you!

--- a/actin_curator.sh
+++ b/actin_curator.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+exit_handler() {
+  exit_code=$?
+  [[ $exit_code -ne 0 ]] && echo "ERROR: Non-zero exit code [$exit_code] from previous command"
+  exit $exit_code  
+}
+
+die() {
+  echo "$@"
+  exit 1
+}
+
+trap exit_handler EXIT
+
+[[ $# -eq 2 ]] || die "Provide the Docker image id and the local directory which will contain input/output"
+in_dir="$2/input"
+for dir in "$in_dir" "$2/output"; do
+  mkdir -p $dir || die "Could not create/verify [$dir]"
+done
+input="$in_dir/criteria.txt"
+[[ -f $input ]] || die "Cannot find input file [$input]"
+
+gc_home="${CLOUDSDK_CONFIG:-$(gcloud info --format='value(config.paths.global_config_dir)')}"
+[[ -n $gc_home ]] || die "Could not determine gcloud config directory! Export CLOUDSDK_CONFIG maybe."
+echo "Using gcloud configured in [$gc_home]"
+docker run --mount "type=bind,src=${2},dst=/actin_data" --mount "type=bind,src=${gc_home},dst=/root/.config/gcloud,ro" $1 

--- a/actin_curator/requirements.txt
+++ b/actin_curator/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+openai
+google-genai
+rapidfuzz
+requests


### PR DESCRIPTION
Add a `Dockerfile` to make running the `actin_curator` easy. Potentially
in future this same file could be used to run the other entry points but
for now I focused on the the unmet need for ACTIN.

Also add a `requirements.txt` for `actin_curator` which describes all
required dependencies and a wrapper script, which should work for ACTIN
members to run the container locally.

The wrapper script tries to create a local directory tree which will
contain the input and output files in well-known locations. It also
endeavours to locate the configuration directory for the `gcloud`
command on the user's host.

It bind-mounts both directories into the container on startup and
executes the Python code within.
